### PR TITLE
Changed test-capture to use global variables for mailing list

### DIFF
--- a/Bottle-Racket/testing/ps2a/ps2a_area.rkt
+++ b/Bottle-Racket/testing/ps2a/ps2a_area.rkt
@@ -1,0 +1,30 @@
+#lang racket
+
+;; Racket Unit Testing Libraries
+(require racket/include)
+(require rackunit)
+(require rackunit/text-ui)
+(require rackunit/gui)
+
+;; Suite file for this assignment
+(define suite-name "ps2a")
+(require "ps2a_suite.rkt")
+
+;; Function for recreating a file when running these tests
+(define (remake-file file-path)
+  (if (file-exists? file-path)
+      (delete-file file-path) 0))
+
+;; map is used here to allow each test suite to be run in the textual interface.
+(remake-file "test_results.txt")
+(define test-result-file (open-output-file "test_results.txt"))
+(current-error-port test-result-file) ; File containing failed cases
+(define num-tests 15)
+(define num-failed (car (map run-tests test-list))) ; run-tests returns list with number of failed cases
+(define num-passed (- num-tests num-failed)) ; How many passed
+(define failed (/ num-failed num-tests))
+(define successful (/ num-passed num-tests))
+(close-output-port test-result-file)
+
+(provide (all-defined-out))
+

--- a/Bottle-Racket/testing/ps2a/ps2a_suite.rkt
+++ b/Bottle-Racket/testing/ps2a/ps2a_suite.rkt
@@ -1,0 +1,33 @@
+#lang racket
+
+(require rackunit)
+(require "ps2a.rkt")
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(define-test-suite ps2a
+  #:before (lambda () (display "Starting Test Suite 'ps2a'\n"))
+  #:after (lambda () (display "Finished Test Suite 'ps2a'\n"))
+  (test-case "add" (check-equal? add #t))
+  (test-case "(f-recursive 2)" (check-equal? (f-recursive 2) 2))
+  (test-case "(f-recursive 3)" (check-equal? (f-recursive 3) 4))
+  (test-case "(f-recursive 4)" (check-equal? (f-recursive 4) 11))
+  (test-case "(f-iterative 2)" (check-equal? (f-iterative 2) 2))
+  (test-case "(f-iterative 3)" (check-equal? (f-iterative 3) 4))
+  (test-case "(f-iterative 5)" (check-equal? (f-iterative 5) 25))
+  (test-case "tail-recursion" (check-equal? tail-recursion #t))
+  (test-case "(fast-expt 2 0)" (check-equal? (fast-expt 2 0) 1))
+  (test-case "(fast-expt 2 1)" (check-equal? (fast-expt 2 1) 2))
+  (test-case "(fast-expt 2 2)" (check-equal? (fast-expt 2 2) 4))
+  (test-case "(fast-expt 2 3)" (check-equal? (fast-expt 2 3) 8))
+  (test-case "(fast-expt 2 5)" (check-equal? (fast-expt 2 5) 32))
+  (test-case "(sum square 2 inc 4)" (check-equal? (sum square 2 inc 4) 29))
+  (test-case "(sum square 2 inc 2)" (check-equal? (sum square 2 inc 2) 4))
+)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define test-list (list
+  ps2a
+))
+
+(provide (all-defined-out))
+

--- a/Bottle-Racket/testing/ps2a/test_results.txt
+++ b/Bottle-Racket/testing/ps2a/test_results.txt
@@ -1,0 +1,2 @@
+Starting Test Suite 'ps2a'
+Finished Test Suite 'ps2a'

--- a/Bottle-Racket/testing/ps2a/test_script.rkt
+++ b/Bottle-Racket/testing/ps2a/test_script.rkt
@@ -169,7 +169,7 @@
 ;; **********************************************************************
 
 ;; This line will run the tests
-(require "ps1_area.rkt")
+(require "ps2a_area.rkt")
 
 ;; Read in the lines from the test results file
 (define file-lines (file->lines "test_results.txt"))

--- a/Bottle-Racket/testing/ps3a/ps3a_area.rkt
+++ b/Bottle-Racket/testing/ps3a/ps3a_area.rkt
@@ -1,0 +1,30 @@
+#lang racket
+
+;; Racket Unit Testing Libraries
+(require racket/include)
+(require rackunit)
+(require rackunit/text-ui)
+(require rackunit/gui)
+
+;; Suite file for this assignment
+(define suite-name "ps3a")
+(require "ps3a_suite.rkt")
+
+;; Function for recreating a file when running these tests
+(define (remake-file file-path)
+  (if (file-exists? file-path)
+      (delete-file file-path) 0))
+
+;; map is used here to allow each test suite to be run in the textual interface.
+(remake-file "test_results.txt")
+(define test-result-file (open-output-file "test_results.txt"))
+(current-error-port test-result-file) ; File containing failed cases
+(define num-tests 15)
+(define num-failed (car (map run-tests test-list))) ; run-tests returns list with number of failed cases
+(define num-passed (- num-tests num-failed)) ; How many passed
+(define failed (/ num-failed num-tests))
+(define successful (/ num-passed num-tests))
+(close-output-port test-result-file)
+
+(provide (all-defined-out))
+

--- a/Bottle-Racket/testing/ps3a/ps3a_suite.rkt
+++ b/Bottle-Racket/testing/ps3a/ps3a_suite.rkt
@@ -1,0 +1,33 @@
+#lang racket
+
+(require rackunit)
+(require "ps3a.rkt")
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(define-test-suite ps3a
+  #:before (lambda () (display "Starting Test Suite 'ps3a'\n"))
+  #:after (lambda () (display "Finished Test Suite 'ps3a'\n"))
+  (test-case "(print-point (midpoint-segment (make-segment (make-point 0 0) (make-point 2 2))))" (check-equal? (midpoint-segment (make-segment (make-point 0 0) (make-point 2 2))) '(1 1)))
+  (test-case "(area-rect (make-rect (make-point 1 1) (make-point 3 7)))" (check-equal? (area-rect (make-rect (make-point 1 1) (make-point 3 7))) 12))
+  (test-case "(perimeter-rect (make-rect (make-point 1 1) (make-point 3 7)))" (check-equal? (perimeter-rect (make-rect (make-point 1 1) (make-point 3 7))) 16))
+  (test-case "my-cdr" (check-equal? (my-cdr (my-cons 14 15)) 15))
+  (test-case "p5" (check-equal? p4 #t))
+  (test-case "(list-prod-iter '(1 2 3 4))" (check-equal? (list-prod-iter '(1 2 3 4)) 24))
+  (test-case "(double-list1 '(1 2 3))" (check-equal? (double-list1 '(1 2 3)) '(2 4 6)))
+  (test-case "(double-list2 '(1 2 3))" (check-equal? (double-list2 '(1 2 3)) '(2 4 6)))
+  (test-case "(double-list2 '(1 2 3))" (check-equal? (double-list3 '(1 2 3)) '(2 4 6)))
+  (test-case "(square-list1 '(1 2 3))" (check-equal? (square-list1 '(1 2 3)) '(1 4 9)))
+  (test-case "(square-list2 '(1 2 3))" (check-equal? (square-list2 '(1 2 3)) '(1 4 9)))
+  (test-case "(my-map square '(1 2 3))" (check-equal? (my-map square '(1 2 3)) '(1 4 9)))
+  (test-case "(my-append '(1 2) '(3 4))" (check-equal? (my-append '(1 2) '(3 4)) '(1 2 3 4)))
+  (test-case "(my-length '(1 2 3 4))" (check-equal? (my-length '(1 2 3 4)) 4))
+  (test-case "(count-leaves '(1 (2 3) 4 (5 6)))" (check-equal? (count-leaves '(1 (2 3) 4 (5 6))) 6))
+)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define test-list (list
+  ps3a
+))
+
+(provide (all-defined-out))
+

--- a/Bottle-Racket/testing/ps3a/test_results.txt
+++ b/Bottle-Racket/testing/ps3a/test_results.txt
@@ -1,0 +1,13 @@
+Starting Test Suite 'ps3a'
+--------------------
+ps3a > (print-point (midpoint-segment (make-segment (make-point 0 0) (make-point 2 2))))
+(print-point (midpoint-segment (make-segment (make-point 0 0) (make-point 2 2))))
+FAILURE
+name:       check-equal?
+location:   ps3a_suite.rkt:10:97
+actual:     '(1 . 1)
+expected:   '(1 1)
+Check failure
+--------------------
+Finished Test Suite 'ps3a'
+14 success(es) 1 failure(s) 0 error(s) 15 test(s) run

--- a/Bottle-Racket/testing/ps3a/test_script.rkt
+++ b/Bottle-Racket/testing/ps3a/test_script.rkt
@@ -169,7 +169,7 @@
 ;; **********************************************************************
 
 ;; This line will run the tests
-(require "ps1_area.rkt")
+(require "ps3a_area.rkt")
 
 ;; Read in the lines from the test results file
 (define file-lines (file->lines "test_results.txt"))


### PR DESCRIPTION
Now there are three buttons on the test-capture gui. One is for creating the test running script, the second is for configuring the email list, and the third is for actually running the test script and then sending results to the email list specified. I recorded a demo here: https://www.youtube.com/watch?v=PwUrjR4FEVA